### PR TITLE
cmake overhaul: some fixes after changes from develop

### DIFF
--- a/src/arch/posix/CMakeLists.txt
+++ b/src/arch/posix/CMakeLists.txt
@@ -27,7 +27,6 @@ add_library(forte-arch-posix OBJECT
     ../genforte_printer.cpp
     ../genforte_fileio.cpp
     ../utils/timespec_utils.cpp
-    ../genforte_realFunctions.cpp
     ../common/forte_specific_architecture.cpp
     $<$<BOOL:${FORTE_COM_ETH}>:../fdselecthand.cpp>
     $<$<BOOL:${FORTE_COM_ETH}>:../bsdsocketinterf.cpp>

--- a/src/com/HTTP/httplayer.cpp
+++ b/src/com/HTTP/httplayer.cpp
@@ -23,7 +23,7 @@
 #include "basecommfb.h"
 #include "http_handler.h"
 #include "comtypes.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 using namespace std::string_literals;

--- a/src/com/modbus/modbuslayer.cpp
+++ b/src/com/modbus/modbuslayer.cpp
@@ -14,7 +14,7 @@
 #include "modbuslayer.h"
 #include "commfb.h"
 #include "modbusclientconnection.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/com/opc_ua/opcua_action_info.cpp
+++ b/src/com/opc_ua/opcua_action_info.cpp
@@ -15,7 +15,7 @@
 #include "opcua_action_info.h"
 #include "core/util/parameterParser.h"
 #include "core/cominfra/basecommfb.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 const char *const CActionInfo::mActionNames[] = {"READ",           "WRITE",         "CREATE_METHOD",   "CALL_METHOD",
                                                  "SUBSCRIBE",      "CREATE_OBJECT", "CREATE_VARIABLE", "DELETE_OBJECT",

--- a/src/com/opc_ua/opcua_helper.cpp
+++ b/src/com/opc_ua/opcua_helper.cpp
@@ -20,7 +20,7 @@
 #include "forte_date.h"
 #include "forte_struct.h"
 #include "forte_array.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 static const CIEC_DATE::TValueType internalToOPCUAEpochDifferenceInNanoseconds = 11644473600000000LL;
 

--- a/src/com/opc_ua/opcua_objectstruct_helper.cpp
+++ b/src/com/opc_ua/opcua_objectstruct_helper.cpp
@@ -22,7 +22,7 @@ USE_STRING_ID(OPCUA_Namespace);
 #include "opcua_local_handler.h"
 #include "core/util/parameterParser.h"
 #include <sstream>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/com/powerlink/EplXmlReader.cpp
+++ b/src/com/powerlink/EplXmlReader.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <string.h>
 #include "devlog.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 #include <tinyxml.h>
 
 using namespace std;

--- a/src/com/tsn/tsn_layer.cpp
+++ b/src/com/tsn/tsn_layer.cpp
@@ -17,7 +17,7 @@
 #include "commfb.h"
 #include <stdio.h>
 #include "parameterParser.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/basefb.cpp
+++ b/src/core/basefb.cpp
@@ -19,7 +19,7 @@
 
 #include "basefb.h"
 #include "resource.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 TPortId SInternalVarsInformation::getVarId(CStringDictionary::TStringId paInternalName) const {
   for (TPortId i = 0; i < mNumIntVars; ++i) {

--- a/src/core/cominfra/commfb.cpp
+++ b/src/core/cominfra/commfb.cpp
@@ -26,8 +26,8 @@
 #include "commfb.h"
 #include "comlayer.h"
 #include "comlayersmanager.h"
-#include "criticalregion.h"
-#include "string_utils.h"
+#include "core/util/criticalregion.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(BOOL);
 USE_STRING_ID(CNF);

--- a/src/core/cominfra/ipcomlayer.cpp
+++ b/src/core/cominfra/ipcomlayer.cpp
@@ -18,7 +18,7 @@
 #include "../../arch/devlog.h"
 #include "basecommfb.h"
 #include <forte_thread.h>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/cominfra/structmembercomlayer.cpp
+++ b/src/core/cominfra/structmembercomlayer.cpp
@@ -17,7 +17,7 @@
 #include "typelib.h"
 #include <string>
 #include <errno.h>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/datatypes/forte_any_elementary.cpp
+++ b/src/core/datatypes/forte_any_elementary.cpp
@@ -15,7 +15,7 @@
  *   Markus Meingast, Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte_any_elementary.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 #include <stdlib.h>
 #include <errno.h>
 #include "forte_sint.h"

--- a/src/core/datatypes/forte_any_string.cpp
+++ b/src/core/datatypes/forte_any_string.cpp
@@ -18,7 +18,7 @@
 #include <fortenew.h>
 #include "forte_any_string.h"
 #include "unicode_utils.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 #include <string.h>
 #include <stdlib.h>
 #include <devlog.h>

--- a/src/core/datatypes/forte_char.cpp
+++ b/src/core/datatypes/forte_char.cpp
@@ -15,7 +15,7 @@
  *   Martin Jobst - fix line feed and newline escape sequences
  *******************************************************************************/
 #include "forte_char.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(CHAR);
 

--- a/src/core/datatypes/forte_date_and_time.cpp
+++ b/src/core/datatypes/forte_date_and_time.cpp
@@ -20,7 +20,7 @@
 #include <ctype.h>
 #include "forte_date_and_time.h"
 #include "forte_architecture_time.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(DATE_AND_TIME);
 

--- a/src/core/datatypes/forte_ldate_and_time.cpp
+++ b/src/core/datatypes/forte_ldate_and_time.cpp
@@ -20,7 +20,7 @@
 #include <ctype.h>
 #include "forte_ldate_and_time.h"
 #include "forte_architecture_time.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(LDATE_AND_TIME);
 

--- a/src/core/datatypes/forte_ltime.cpp
+++ b/src/core/datatypes/forte_ltime.cpp
@@ -18,8 +18,8 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte_ltime.h"
-#include "forte_constants.h"
-#include "string_utils.h"
+#include "core/util/forte_constants.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(LTIME);
 

--- a/src/core/datatypes/forte_ltime_of_day.cpp
+++ b/src/core/datatypes/forte_ltime_of_day.cpp
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte_ltime_of_day.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(LTIME_OF_DAY);
 

--- a/src/core/datatypes/forte_string.cpp
+++ b/src/core/datatypes/forte_string.cpp
@@ -27,7 +27,7 @@
 #include <string_view>
 #include <charconv>
 #include "../../arch/forte_fileio.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(STRING);
 

--- a/src/core/datatypes/forte_time.cpp
+++ b/src/core/datatypes/forte_time.cpp
@@ -19,8 +19,8 @@
 #include "forte_time.h"
 #include <string_view>
 #include "../../arch/timerha.h"
-#include "forte_constants.h"
-#include "string_utils.h"
+#include "core/util/forte_constants.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(TIME);
 

--- a/src/core/datatypes/forte_time_of_day.cpp
+++ b/src/core/datatypes/forte_time_of_day.cpp
@@ -20,7 +20,7 @@
 #include <ctype.h>
 #include "forte_time_of_day.h"
 #include "forte_architecture_time.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(TIME_OF_DAY);
 

--- a/src/core/datatypes/forte_wchar.cpp
+++ b/src/core/datatypes/forte_wchar.cpp
@@ -17,7 +17,7 @@
 #include "forte_wchar.h"
 #include <cstdint>
 #include <format>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(WCHAR);
 

--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -31,7 +31,7 @@
 #include "adapter.h"
 #include "adapterconn.h"
 #include "device.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 using namespace std::string_literals;
 

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -32,7 +32,7 @@ USE_STRING_ID(START);
 #include "generated/ecetFactory.h"
 #include "device.h"
 #include "negdataconn.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 #ifdef FORTE_DYNAMIC_TYPE_LOAD
 #include "lua/luaadaptertypeentry.h"

--- a/src/core/typelib.cpp
+++ b/src/core/typelib.cpp
@@ -20,7 +20,7 @@
 #include "adapterconn.h"
 #include "adapter.h"
 #include <stddef.h>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ARRAY);
 

--- a/src/core/util/string_utils.cpp
+++ b/src/core/util/string_utils.cpp
@@ -12,7 +12,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 #include "../datatypes/forte_dint.h"
 #include "../datatypes/forte_udint.h"
 #include "../datatypes/forte_lint.h"

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 #include "GEN_ADD_fbt.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ANY_MAGNITUDE);
 USE_STRING_ID(CNF);

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -16,7 +16,7 @@
  *******************************************************************************/
 #include "genbitbase_fbt.h"
 #include <memory>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ANY_BIT);
 USE_STRING_ID(CNF);

--- a/src/modules/rt_events/RT_Bridge_fbt.cpp
+++ b/src/modules/rt_events/RT_Bridge_fbt.cpp
@@ -14,7 +14,7 @@
 #include "RT_Bridge_fbt.h"
 #include <memory>
 #include "criticalregion.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ANY);
 USE_STRING_ID(Event);

--- a/src/modules/utils/GEN_ARRAY2ARRAY_fbt.cpp
+++ b/src/modules/utils/GEN_ARRAY2ARRAY_fbt.cpp
@@ -16,7 +16,7 @@
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_ARRAY2ARRAY_fbt.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);

--- a/src/modules/utils/GEN_ARRAY2VALUES_fbt.cpp
+++ b/src/modules/utils/GEN_ARRAY2VALUES_fbt.cpp
@@ -18,7 +18,7 @@
  *******************************************************************************/
 #include "GEN_ARRAY2VALUES_fbt.h"
 #include <memory>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);

--- a/src/modules/utils/GEN_CSV_WRITER_fbt.cpp
+++ b/src/modules/utils/GEN_CSV_WRITER_fbt.cpp
@@ -18,7 +18,7 @@
  *******************************************************************************/
 #include "GEN_CSV_WRITER_fbt.h"
 #include <memory>
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(BOOL);
 USE_STRING_ID(CNF);

--- a/src/modules/utils/GEN_VALUES2ARRAY_fbt.cpp
+++ b/src/modules/utils/GEN_VALUES2ARRAY_fbt.cpp
@@ -19,7 +19,7 @@
 #include "GEN_VALUES2ARRAY_fbt.h"
 #include <memory>
 #include "forte_printer.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);

--- a/src/stdfblib/events/GEN_E_DEMUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_DEMUX_fbt.cpp
@@ -16,7 +16,7 @@
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_E_DEMUX_fbt.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(EI);
 USE_STRING_ID(Event);

--- a/src/stdfblib/events/GEN_E_MUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.cpp
@@ -18,7 +18,7 @@
  *....Franz Höpfinger - Update it to represent latest Generation Format from 4diac IDE. no Functional Changes.
  *******************************************************************************/
 #include "GEN_E_MUX_fbt.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(EO);
 USE_STRING_ID(Event);

--- a/src/stdfblib/events/GEN_E_SPLIT_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_SPLIT_fbt.cpp
@@ -13,7 +13,7 @@
  *******************************************************************************/
 
 #include "GEN_E_SPLIT_fbt.h"
-#include "string_utils.h"
+#include "core/util/string_utils.h"
 
 USE_STRING_ID(EI);
 USE_STRING_ID(GEN_E_SPLIT);


### PR DESCRIPTION
Fix include prefixes and a removed source due to incoming changes from develop.